### PR TITLE
Swiftlint: Rename 'variable_name' to 'identifier_name'

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,7 @@ type_body_length:
 function_body_length:
   - 30 # warning
   - 50 # error
-variable_name:
+identifier_name:
   max_length:
     warning: 60
     error: 80


### PR DESCRIPTION
Fixed the following warning.

> Showing Recent Messages
'variable_name' rule has been renamed to 'identifier_name' and will be completely removed in a future release.

![2017-08-07 15 36 54](https://user-images.githubusercontent.com/893643/29020279-69ca74ec-7b9c-11e7-9286-34ddce1444b9.png)


## Link

* [variable\_name rule should extend to all identifiers · Issue \#663 · realm/SwiftLint](https://github.com/realm/SwiftLint/issues/663)
